### PR TITLE
Fix incorrect Patreon link

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -106,7 +106,7 @@
                 <tbody class="text-base md:text-lg">
                     <tr class="tag">
                         <th scope="row" class="font-bold">Patreon</th>
-                        <th class="font-normal"><a href="patreon.com/CLCK0622" class="link" target="_blank">@CLCK0622</a></th>
+                        <th class="font-normal"><a href="https://www.patreon.com/CLCK0622" class="link" target="_blank">@CLCK0622</a></th>
                     </tr>
                 </tbody>
             </table>


### PR DESCRIPTION
The `href` of the link to Patreon doesn't start with `https://`, so it is misunderstood by the browser, which leads the user to a incorrect relative location.